### PR TITLE
Resolve bug where XHTwitterPaggingViewer was incorrect height when inside a UITabBarController

### DIFF
--- a/XHTwitterPaggingViewer/XHTwitterPaggingViewer.m
+++ b/XHTwitterPaggingViewer/XHTwitterPaggingViewer.m
@@ -180,6 +180,13 @@ typedef NS_ENUM(NSInteger, XHSlideType) {
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
+    
+    // Ensure that the paggingScrollView is the correct height.
+    // This facilitates situations where the XHTwitterPaggingViewer is shown within
+    // a UITabBarController.
+    CGRect scrollViewFrame = self.paggingScrollView.frame;
+    scrollViewFrame.size.height = self.view.frame.size.height;
+    self.paggingScrollView.frame = scrollViewFrame;
 }
 
 - (void)viewDidLoad {


### PR DESCRIPTION
Hey,

I fixed a bug that was causing my scrollviews to have an incorrect height when displayed in a UITabBarController.

Before my fix:

![xhtwitterpaggingviewer_before](https://cloud.githubusercontent.com/assets/296341/3836736/723d8b4a-1ddb-11e4-877c-8bb51a1998e2.gif)

After:

![xhtwitterpaggingviewer_after](https://cloud.githubusercontent.com/assets/296341/3836738/74d85a42-1ddb-11e4-82d9-ab1e53a8ffa0.gif)
