### PR TITLE
Call viewWillDisappear and viewWillAppear when scrolling to and away from view controllers

### DIFF
--- a/XHTwitterPaggingViewer/XHTwitterPaggingViewer.m
+++ b/XHTwitterPaggingViewer/XHTwitterPaggingViewer.m
@@ -280,7 +280,9 @@ typedef NS_ENUM(NSInteger, XHSlideType) {
     UIViewController *toViewController = [self.viewControllers objectAtIndex:self.currentPage];
 
     [fromViewController viewWillDisappear: true];
+    [fromViewController viewDidDisappear: true];
     [toViewController viewWillAppear: true];
+    [toViewController viewDidAppear: true];
 
     if (self.didChangedPageCompleted) {
         self.didChangedPageCompleted(self.currentPage, [[self.viewControllers valueForKey:@"title"] objectAtIndex:self.currentPage]);


### PR DESCRIPTION
There was no way for a UIViewController to handle events where their views were no longer being shown by the XHTwitterPaggingViewer.

So I added a call to viewWill/Did(Appear/Disappear) on the corresponding view controllers when the user swipes either way on the XHTwitterPaggingViewer.

Now you can do things like have a UITextField become first responder when the user swipes to a view.
