### PR TITLE
Fix: Use backgroundColor of superview for centerContainerView

### DIFF
--- a/XHTwitterPaggingViewer/XHTwitterPaggingViewer.m
+++ b/XHTwitterPaggingViewer/XHTwitterPaggingViewer.m
@@ -88,7 +88,7 @@ typedef NS_ENUM(NSInteger, XHSlideType) {
 - (UIView *)centerContainerView {
     if (!_centerContainerView) {
         _centerContainerView = [[UIView alloc] initWithFrame:self.view.bounds];
-        _centerContainerView.backgroundColor = [UIColor whiteColor];
+        _centerContainerView.backgroundColor = self.view.backgroundColor;
         
         [_centerContainerView addSubview:self.paggingScrollView];
         [self.paggingScrollView.panGestureRecognizer addTarget:self action:@selector(panGestureRecognizerHandle:)];


### PR DESCRIPTION
Allows to use color set in storyboard for background color of all subviews.
There is no way to do this from library user code, he is stuck with white color.

Biggest problem (use case): controller inside pager needs to be set to clearColor,
because we use window background image pattern.
